### PR TITLE
Make the UI crispy clean on all screen sizes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
                     primary_window: Some(Window {
                         title: "City Idle".into(),
                         mode: WindowMode::BorderlessFullscreen,
-                        resizable: false,
+                        resizable: true,
                         ..default()
                     }),
                     ..default()

--- a/src/ui/construct.rs
+++ b/src/ui/construct.rs
@@ -152,7 +152,14 @@ fn draw_construct(
     primary_window: Query<&Window, With<PrimaryWindow>>,
     item_icons: Res<ItemIcons>,
 ) {
-    let physical_screen_height = primary_window.single().resolution.physical_height() as f32;
+    // UI takes up half the screen & renders at a ratio of 1:1.777
+    let mut inventory_width = primary_window.single().resolution.width() / 2.0;
+    let mut inventory_height = inventory_width / (1920.0 / 1080.0);
+
+    if inventory_height > primary_window.single().resolution.height() {
+        inventory_height = primary_window.single().resolution.height() / 2.0;
+        inventory_width = inventory_height * (1920.0 / 1080.0);
+    }
 
     commands
         .spawn(NodeBundle {
@@ -169,13 +176,16 @@ fn draw_construct(
             commands
                 .spawn(NodeBundle {
                     style: Style {
-                        size: Size::new(Val::Percent(50.0), Val::Percent(50.0)),
+                        size: Size::new(Val::Px(inventory_width), Val::Px(inventory_height)),
                         flex_direction: FlexDirection::Row,
                         justify_content: JustifyContent::SpaceEvenly,
                         align_items: AlignItems::Center,
                         align_content: AlignContent::SpaceAround,
                         align_self: AlignSelf::Center,
-                        margin: UiRect::left(Val::Percent(25.0)),
+                        margin: UiRect::left(Val::Px(
+                            // Offset required for the centre of inventory width to align with centre of screen
+                            (primary_window.single().resolution.width() - inventory_width) / 2.0,
+                        )),
                         ..default()
                     },
                     background_color: Color::rgb(0.13, 0.14, 0.26).into(),
@@ -221,7 +231,7 @@ fn draw_construct(
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
                                                     // Font size 40 looked nice on my own screen height of 2880, which is a ratio of 1:72
-                                                    font_size: physical_screen_height / 72.0,
+                                                    font_size: inventory_width / 36.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -241,7 +251,7 @@ fn draw_construct(
                                                 "[[ The Construct Shop ]]".to_string(),
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 72.0,
+                                                    font_size: inventory_width / 36.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -295,8 +305,8 @@ fn draw_construct(
                                                 commands.spawn(ImageBundle {
                                                     style: Style {
                                                         size: Size::new(
-                                                            Val::Percent(5.0 * (100.0 / 6.0)),
-                                                            Val::Percent(5.0 * (100.0 / 5.0)),
+                                                            Val::Px(inventory_width / 17.5),
+                                                            Val::Px(inventory_width / 17.5),
                                                         ),
                                                         ..default()
                                                     },
@@ -349,7 +359,7 @@ fn draw_construct(
                                                             },
                                                             TextStyle {
                                                                 font: asset_server.load("font.otf"),
-                                                                font_size: physical_screen_height / 108.0,
+                                                                font_size: inventory_width / 54.0,
                                                                 color: Color::WHITE,
                                                             },
                                                         ),
@@ -394,7 +404,7 @@ fn draw_construct(
                                             "Item name",
                                             TextStyle {
                                                 font: asset_server.load("font.otf"),
-                                                font_size: physical_screen_height / 60.0,
+                                                font_size: inventory_width / 30.0,
                                                 color: Color::WHITE,
                                             },
                                         ))
@@ -419,7 +429,11 @@ fn draw_construct(
                                         .spawn(ImageBundle {
                                             image: item_icons.empty.clone().into(),
                                             style: Style {
-                                                size: Size::new(Val::Percent(50.0), Val::Percent(100.0)),
+                                                // size: Size::new(Val::Percent(50.0), Val::Percent(100.0)),
+                                                size: Size::new(
+                                                    Val::Px(inventory_width / 4.0),
+                                                    Val::Px(inventory_width / 4.0),
+                                                ),
                                                 ..default()
                                             },
                                             transform: Transform::from_scale(Vec3::splat(0.8)),
@@ -453,7 +467,7 @@ fn draw_construct(
                                                 "Remaining: #",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 90.0,
+                                                    font_size: inventory_width / 45.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -487,7 +501,7 @@ fn draw_construct(
                                                 "Price: $",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 90.0,
+                                                    font_size: inventory_width / 45.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -527,7 +541,7 @@ fn draw_construct(
                                                 "BUY",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 60.0,
+                                                    font_size: inventory_width / 30.0,
                                                     color: Color::WHITE,
                                                 },
                                             ));

--- a/src/ui/inventory.rs
+++ b/src/ui/inventory.rs
@@ -161,7 +161,14 @@ fn draw_inventory(
         }
     }
 
-    let physical_screen_height = primary_window.single().resolution.physical_height() as f32;
+    // UI takes up half the screen & renders at a ratio of 1:1.777
+    let mut inventory_width = primary_window.single().resolution.width() / 2.0;
+    let mut inventory_height = inventory_width / (1920.0 / 1080.0);
+
+    if inventory_height > primary_window.single().resolution.height() {
+        inventory_height = primary_window.single().resolution.height() / 2.0;
+        inventory_width = inventory_height * (1920.0 / 1080.0);
+    }
 
     commands
         .spawn(NodeBundle {
@@ -179,13 +186,15 @@ fn draw_inventory(
             commands
                 .spawn(NodeBundle {
                     style: Style {
-                        size: Size::new(Val::Percent(50.0), Val::Percent(50.0)),
+                        size: Size::new(Val::Px(inventory_width), Val::Px(inventory_height)),
                         flex_direction: FlexDirection::Row,
                         justify_content: JustifyContent::SpaceEvenly,
                         align_items: AlignItems::Center,
-                        align_content: AlignContent::SpaceAround,
                         align_self: AlignSelf::Center,
-                        margin: UiRect::left(Val::Percent(25.0)),
+                        margin: UiRect::left(Val::Px(
+                            // Offset required for the centre of inventory width to align with centre of screen
+                            (primary_window.single().resolution.width() - inventory_width) / 2.0,
+                        )),
                         ..default()
                     },
                     background_color: Color::rgb(0.13, 0.14, 0.26).into(),
@@ -235,7 +244,7 @@ fn draw_inventory(
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
                                                     // Font size 40 looked nice on my own screen height of 2880, which is a ratio of 1:72
-                                                    font_size: physical_screen_height / 72.0,
+                                                    font_size: inventory_width / 36.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -254,7 +263,7 @@ fn draw_inventory(
                                                 format!("City Centre: Level {}", city_centre_level),
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 72.0,
+                                                    font_size: inventory_width / 36.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -308,10 +317,9 @@ fn draw_inventory(
                                                 // Item icon
                                                 commands.spawn(ImageBundle {
                                                     style: Style {
-                                                        // size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                                                         size: Size::new(
-                                                            Val::Percent(5.0 * (100.0 / 6.0)),
-                                                            Val::Percent(5.0 * (100.0 / 5.0)),
+                                                            Val::Px(inventory_width / 17.5),
+                                                            Val::Px(inventory_width / 17.5),
                                                         ),
                                                         ..default()
                                                     },
@@ -378,7 +386,7 @@ fn draw_inventory(
                                                             },
                                                             TextStyle {
                                                                 font: asset_server.load("font.otf"),
-                                                                font_size: physical_screen_height / 108.0,
+                                                                font_size: inventory_width / 54.0,
                                                                 color: Color::WHITE,
                                                             },
                                                         ),
@@ -431,7 +439,7 @@ fn draw_inventory(
                                             "Item name",
                                             TextStyle {
                                                 font: asset_server.load("font.otf"),
-                                                font_size: physical_screen_height / 60.0,
+                                                font_size: inventory_width / 30.0,
                                                 color: Color::WHITE,
                                             },
                                         ))
@@ -456,7 +464,10 @@ fn draw_inventory(
                                         .spawn(ImageBundle {
                                             image: item_icons.empty.clone().into(),
                                             style: Style {
-                                                size: Size::new(Val::Percent(50.0), Val::Percent(100.0)),
+                                                size: Size::new(
+                                                    Val::Px(inventory_width / 4.0),
+                                                    Val::Px(inventory_width / 4.0),
+                                                ),
                                                 ..default()
                                             },
                                             transform: Transform::from_scale(Vec3::splat(0.8)),
@@ -490,7 +501,7 @@ fn draw_inventory(
                                                 "Quantity: #",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 90.0,
+                                                    font_size: inventory_width / 45.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -524,7 +535,7 @@ fn draw_inventory(
                                                 "Sell: $",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 90.0,
+                                                    font_size: inventory_width / 45.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -547,19 +558,9 @@ fn draw_inventory(
                                     ..default()
                                 })
                                 .with_children(|commands| {
-                                    spawn_quantity_increment_button(
-                                        commands,
-                                        &asset_server,
-                                        -10,
-                                        physical_screen_height,
-                                    );
+                                    spawn_quantity_increment_button(commands, &asset_server, -10, inventory_width);
 
-                                    spawn_quantity_increment_button(
-                                        commands,
-                                        &asset_server,
-                                        -1,
-                                        physical_screen_height,
-                                    );
+                                    spawn_quantity_increment_button(commands, &asset_server, -1, inventory_width);
 
                                     // Quantity selected
                                     commands
@@ -577,7 +578,7 @@ fn draw_inventory(
                                                 "0",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 60.0,
+                                                    font_size: inventory_width / 30.0,
                                                     color: Color::GREEN,
                                                 },
                                             ),
@@ -588,14 +589,9 @@ fn draw_inventory(
                                             sell_allowed: false,
                                         });
 
-                                    spawn_quantity_increment_button(commands, &asset_server, 1, physical_screen_height);
+                                    spawn_quantity_increment_button(commands, &asset_server, 1, inventory_width);
 
-                                    spawn_quantity_increment_button(
-                                        commands,
-                                        &asset_server,
-                                        10,
-                                        physical_screen_height,
-                                    );
+                                    spawn_quantity_increment_button(commands, &asset_server, 10, inventory_width);
                                 });
 
                             // Sell button
@@ -628,7 +624,7 @@ fn draw_inventory(
                                                 "SELL",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 60.0,
+                                                    font_size: inventory_width / 30.0,
                                                     color: Color::WHITE,
                                                 },
                                             ));
@@ -881,7 +877,7 @@ fn spawn_quantity_increment_button(
     commands: &mut ChildBuilder,
     asset_server: &AssetServer,
     amount: i8,
-    physical_screen_height: f32,
+    base_width: f32,
 ) {
     commands
         .spawn(ButtonBundle {
@@ -906,7 +902,7 @@ fn spawn_quantity_increment_button(
                 format!("{}{}", if amount.is_positive() { "+" } else { "-" }, amount.abs()),
                 TextStyle {
                     font: asset_server.load("font.otf"),
-                    font_size: physical_screen_height / 90.0,
+                    font_size: base_width / 45.0,
                     color: Color::WHITE,
                 },
             ));

--- a/src/ui/market.rs
+++ b/src/ui/market.rs
@@ -126,7 +126,14 @@ fn draw_market(
     primary_window: Query<&Window, With<PrimaryWindow>>,
     item_icons: Res<ItemIcons>,
 ) {
-    let physical_screen_height = primary_window.single().resolution.physical_height() as f32;
+    // UI takes up half the screen & renders at a ratio of 1:1.777
+    let mut inventory_width = primary_window.single().resolution.width() / 2.0;
+    let mut inventory_height = inventory_width / (1920.0 / 1080.0);
+
+    if inventory_height > primary_window.single().resolution.height() {
+        inventory_height = primary_window.single().resolution.height() / 2.0;
+        inventory_width = inventory_height * (1920.0 / 1080.0);
+    }
 
     commands
         .spawn(NodeBundle {
@@ -143,13 +150,16 @@ fn draw_market(
             commands
                 .spawn(NodeBundle {
                     style: Style {
-                        size: Size::new(Val::Percent(50.0), Val::Percent(50.0)),
+                        size: Size::new(Val::Px(inventory_width), Val::Px(inventory_height)),
                         flex_direction: FlexDirection::Row,
                         justify_content: JustifyContent::SpaceEvenly,
                         align_items: AlignItems::Center,
                         align_content: AlignContent::SpaceAround,
                         align_self: AlignSelf::Center,
-                        margin: UiRect::left(Val::Percent(25.0)),
+                        margin: UiRect::left(Val::Px(
+                            // Offset required for the centre of inventory width to align with centre of screen
+                            (primary_window.single().resolution.width() - inventory_width) / 2.0,
+                        )),
                         ..default()
                     },
                     background_color: Color::rgb(0.96, 0.83, 0.39).into(),
@@ -195,7 +205,7 @@ fn draw_market(
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
                                                     // Font size 40 looked nice on my own screen height of 2880, which is a ratio of 1:72
-                                                    font_size: physical_screen_height / 72.0,
+                                                    font_size: inventory_width / 36.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -215,7 +225,7 @@ fn draw_market(
                                                 "[[ The Market ]]".to_string(),
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 72.0,
+                                                    font_size: inventory_width / 36.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -268,10 +278,9 @@ fn draw_market(
                                                 // Item icon
                                                 commands.spawn(ImageBundle {
                                                     style: Style {
-                                                        // size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                                                         size: Size::new(
-                                                            Val::Percent(5.0 * (100.0 / 6.0)),
-                                                            Val::Percent(5.0 * (100.0 / 5.0)),
+                                                            Val::Px(inventory_width / 17.5),
+                                                            Val::Px(inventory_width / 17.5),
                                                         ),
                                                         ..default()
                                                     },
@@ -338,7 +347,7 @@ fn draw_market(
                                                             },
                                                             TextStyle {
                                                                 font: asset_server.load("font.otf"),
-                                                                font_size: physical_screen_height / 108.0,
+                                                                font_size: inventory_width / 54.0,
                                                                 color: Color::WHITE,
                                                             },
                                                         ),
@@ -391,7 +400,7 @@ fn draw_market(
                                             "Item name",
                                             TextStyle {
                                                 font: asset_server.load("font.otf"),
-                                                font_size: physical_screen_height / 60.0,
+                                                font_size: inventory_width / 30.0,
                                                 color: Color::WHITE,
                                             },
                                         ))
@@ -416,7 +425,10 @@ fn draw_market(
                                         .spawn(ImageBundle {
                                             image: item_icons.empty.clone().into(),
                                             style: Style {
-                                                size: Size::new(Val::Percent(50.0), Val::Percent(100.0)),
+                                                size: Size::new(
+                                                    Val::Px(inventory_width / 4.0),
+                                                    Val::Px(inventory_width / 4.0),
+                                                ),
                                                 ..default()
                                             },
                                             transform: Transform::from_scale(Vec3::splat(0.8)),
@@ -450,7 +462,7 @@ fn draw_market(
                                                 "Quantity: #",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 90.0,
+                                                    font_size: inventory_width / 45.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -484,7 +496,7 @@ fn draw_market(
                                                 "Price: $",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 90.0,
+                                                    font_size: inventory_width / 45.0,
                                                     color: Color::WHITE,
                                                 },
                                             ),
@@ -507,19 +519,9 @@ fn draw_market(
                                     ..default()
                                 })
                                 .with_children(|commands| {
-                                    spawn_quantity_increment_button(
-                                        commands,
-                                        &asset_server,
-                                        -10,
-                                        physical_screen_height,
-                                    );
+                                    spawn_quantity_increment_button(commands, &asset_server, -10, inventory_width);
 
-                                    spawn_quantity_increment_button(
-                                        commands,
-                                        &asset_server,
-                                        -1,
-                                        physical_screen_height,
-                                    );
+                                    spawn_quantity_increment_button(commands, &asset_server, -1, inventory_width);
 
                                     // Quantity selected
                                     commands
@@ -537,7 +539,7 @@ fn draw_market(
                                                 "0",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 60.0,
+                                                    font_size: inventory_width / 30.0,
                                                     color: Color::GREEN,
                                                 },
                                             ),
@@ -548,14 +550,9 @@ fn draw_market(
                                             buy_allowed: false,
                                         });
 
-                                    spawn_quantity_increment_button(commands, &asset_server, 1, physical_screen_height);
+                                    spawn_quantity_increment_button(commands, &asset_server, 1, inventory_width);
 
-                                    spawn_quantity_increment_button(
-                                        commands,
-                                        &asset_server,
-                                        10,
-                                        physical_screen_height,
-                                    );
+                                    spawn_quantity_increment_button(commands, &asset_server, 10, inventory_width);
                                 });
 
                             // Buy button
@@ -588,7 +585,7 @@ fn draw_market(
                                                 "BUY",
                                                 TextStyle {
                                                     font: asset_server.load("font.otf"),
-                                                    font_size: physical_screen_height / 60.0,
+                                                    font_size: inventory_width / 30.0,
                                                     color: Color::WHITE,
                                                 },
                                             ));
@@ -865,7 +862,7 @@ fn spawn_quantity_increment_button(
     commands: &mut ChildBuilder,
     asset_server: &AssetServer,
     amount: i8,
-    physical_screen_height: f32,
+    base_width: f32,
 ) {
     commands
         .spawn(ButtonBundle {
@@ -890,7 +887,7 @@ fn spawn_quantity_increment_button(
                 format!("{}{}", if amount.is_positive() { "+" } else { "-" }, amount.abs()),
                 TextStyle {
                     font: asset_server.load("font.otf"),
-                    font_size: physical_screen_height / 90.0,
+                    font_size: base_width / 45.0,
                     color: Color::WHITE,
                 },
             ));

--- a/src/ui/upgrade.rs
+++ b/src/ui/upgrade.rs
@@ -110,7 +110,14 @@ fn draw_ui(
     mut selected_building_resource: ResMut<SelectedBuilding>,
     upgrade_data: Res<UpgradeData>,
 ) {
-    let physical_screen_height = primary_window.single().resolution.physical_height() as f32;
+    // UI takes up half the screen & renders at a ratio of 1:1.777
+    let mut inventory_width = primary_window.single().resolution.width() / 2.0;
+    let mut inventory_height = inventory_width / (1920.0 / 1080.0);
+
+    if inventory_height > primary_window.single().resolution.height() {
+        inventory_height = primary_window.single().resolution.height() / 2.0;
+        inventory_width = inventory_height * (1920.0 / 1080.0);
+    }
 
     let mut target_building = None;
 
@@ -151,13 +158,16 @@ fn draw_ui(
             commands
                 .spawn(NodeBundle {
                     style: Style {
-                        size: Size::new(Val::Percent(50.0), Val::Percent(50.0)),
+                        size: Size::new(Val::Px(inventory_width), Val::Px(inventory_height)),
                         flex_direction: FlexDirection::Row,
                         justify_content: JustifyContent::SpaceEvenly,
                         align_items: AlignItems::Center,
                         align_content: AlignContent::SpaceAround,
                         align_self: AlignSelf::Center,
-                        margin: UiRect::left(Val::Percent(25.0)),
+                        margin: UiRect::left(Val::Px(
+                            // Offset required for the centre of inventory width to align with centre of screen
+                            (primary_window.single().resolution.width() - inventory_width) / 2.0,
+                        )),
                         ..default()
                     },
                     background_color: Color::rgb(0.13, 0.14, 0.26).into(),
@@ -210,7 +220,7 @@ fn draw_ui(
                                                     target_building.building_type.get_name(),
                                                     TextStyle {
                                                         font: asset_server.load("font.otf"),
-                                                        font_size: physical_screen_height / 72.0,
+                                                        font_size: inventory_width / 36.0,
                                                         color: Color::WHITE,
                                                     },
                                                 ),
@@ -244,7 +254,7 @@ fn draw_ui(
                                                     }),
                                                     TextStyle {
                                                         font: asset_server.load("font.otf"),
-                                                        font_size: physical_screen_height / 84.0,
+                                                        font_size: inventory_width / 42.0,
                                                         color: Color::WHITE,
                                                     },
                                                 ),
@@ -253,11 +263,17 @@ fn draw_ui(
 
                                             commands.spawn(TextBundle {
                                                 style: Style {
-                                                    margin: UiRect::all(Val::Percent(5.0)),
+                                                    // margin: UiRect::all(Val::Percent(5.0)),
+                                                    margin: UiRect::new(
+                                                        Val::Percent(5.0),
+                                                        Val::Percent(5.0),
+                                                        Val::Percent(5.0),
+                                                        Val::Percent(10.0),
+                                                    ),
                                                     ..default()
                                                 },
                                                 text: Text::from_section(
-                                                    format!("Speed {}s → {}s", level_stats.speed, {
+                                                    format!("Speed: {}s → {}s", level_stats.speed, {
                                                         if next_level_stats.is_none() {
                                                             "MAX".to_string()
                                                         } else {
@@ -266,7 +282,7 @@ fn draw_ui(
                                                     }),
                                                     TextStyle {
                                                         font: asset_server.load("font.otf"),
-                                                        font_size: physical_screen_height / 84.0,
+                                                        font_size: inventory_width / 42.0,
                                                         color: Color::WHITE,
                                                     },
                                                 ),
@@ -286,12 +302,14 @@ fn draw_ui(
                                             })
                                             .with_children(|commands| {
                                                 // Image
-                                                // let item_type = level_stats.yields.map(|(item_type, _)| item_type);
-                                                // let y = level_stats.yields;
 
                                                 commands.spawn(ImageBundle {
                                                     style: Style {
-                                                        size: Size::new(Val::Percent(18.0), Val::Percent(100.0)),
+                                                        // size: Size::new(Val::Percent(18.0), Val::Percent(100.0)),
+                                                        size: Size::new(
+                                                            Val::Px(inventory_width / 16.0),
+                                                            Val::Px(inventory_width / 16.0),
+                                                        ),
                                                         margin: UiRect::left(Val::Percent(2.0)),
                                                         ..default()
                                                     },
@@ -337,7 +355,7 @@ fn draw_ui(
                                                         }),
                                                         TextStyle {
                                                             font: asset_server.load("font.otf"),
-                                                            font_size: physical_screen_height / 84.0,
+                                                            font_size: inventory_width / 42.0,
                                                             color: Color::WHITE,
                                                         },
                                                     ),
@@ -350,10 +368,11 @@ fn draw_ui(
                             commands
                                 .spawn(NodeBundle {
                                     style: Style {
-                                        size: Size::new(Val::Percent(100.0), Val::Percent(25.0)),
+                                        size: Size::new(Val::Percent(100.0), Val::Percent(20.0)),
                                         flex_direction: FlexDirection::Row,
                                         justify_content: JustifyContent::SpaceEvenly,
                                         align_items: AlignItems::Center,
+                                        margin: UiRect::top(Val::Percent(5.0)),
                                         ..default()
                                     },
                                     background_color: Color::rgb(0.17, 0.19, 0.36).into(),
@@ -375,7 +394,10 @@ fn draw_ui(
                                             .with_children(|commands| {
                                                 commands.spawn(ImageBundle {
                                                     style: Style {
-                                                        size: Size::new(Val::Percent(75.0), Val::Percent(45.0)),
+                                                        size: Size::new(
+                                                            Val::Px(inventory_width / 30.0),
+                                                            Val::Px(inventory_width / 30.0),
+                                                        ),
                                                         ..default()
                                                     },
                                                     image: UiImage {
@@ -414,7 +436,7 @@ fn draw_ui(
                                                             format!("x{}", target_building.yields[i].1),
                                                             TextStyle {
                                                                 font: asset_server.load("font.otf"),
-                                                                font_size: physical_screen_height / 90.0,
+                                                                font_size: inventory_width / 45.0,
                                                                 color: Color::WHITE,
                                                             },
                                                         ),
@@ -428,7 +450,7 @@ fn draw_ui(
                                     commands
                                         .spawn(ButtonBundle {
                                             style: Style {
-                                                size: Size::new(Val::Percent(30.0), Val::Percent(50.0)),
+                                                size: Size::new(Val::Percent(40.0), Val::Percent(100.0)),
                                                 justify_content: JustifyContent::Center,
                                                 align_items: AlignItems::Center,
                                                 ..default()
@@ -445,7 +467,7 @@ fn draw_ui(
                                                     "COLLECT",
                                                     TextStyle {
                                                         font: asset_server.load("font.otf"),
-                                                        font_size: physical_screen_height / 64.0,
+                                                        font_size: inventory_width / 32.0,
                                                         color: Color::WHITE,
                                                     },
                                                 ),
@@ -486,7 +508,7 @@ fn draw_ui(
                                             "Next Level Requirements",
                                             TextStyle {
                                                 font: asset_server.load("font.otf"),
-                                                font_size: physical_screen_height / 72.0,
+                                                font_size: inventory_width / 36.0,
                                                 color: Color::WHITE,
                                             },
                                         ),
@@ -523,7 +545,10 @@ fn draw_ui(
                                             .with_children(|commands| {
                                                 commands.spawn(ImageBundle {
                                                     style: Style {
-                                                        size: Size::new(Val::Percent(80.0), Val::Percent(45.0)),
+                                                        size: Size::new(
+                                                            Val::Px(inventory_width / 10.0),
+                                                            Val::Px(inventory_width / 10.0),
+                                                        ),
                                                         ..default()
                                                     },
                                                     image: UiImage {


### PR DESCRIPTION
- Enable window resizing
- Changed UI popup from 「50% width x 50% height」to a 「1920 x 1080」resolution
- Changed images to be render at a perfect square resolution